### PR TITLE
chore: parameterize workflow + fix empty data crash

### DIFF
--- a/.github/workflows/daily-report.yml
+++ b/.github/workflows/daily-report.yml
@@ -4,6 +4,15 @@ on:
   schedule:
     - cron: '0 6 * * *'
   workflow_dispatch:
+    inputs:
+      month:
+        description: 'Month (1-12), omit for cron default (next month)'
+        required: false
+        type: number
+      year:
+        description: 'Year YYYY, defaults to current year'
+        required: false
+        type: number
 
 jobs:
   generate-report:
@@ -41,7 +50,14 @@ jobs:
         env:
           EEX_API_HEADER_VALUE: ${{ secrets.EEX_API_HEADER_VALUE }}
           EEX_API_HEADER_KEY: ${{ secrets.EEX_API_HEADER_KEY }}
-        run: poetry run flep --format markdown --output report/
+        run: |
+          ARGS="--format markdown --output report/"
+          if [ -n "${{ inputs.month }}" ]; then
+            YR="${{ inputs.year }}"
+            [ -z "$YR" ] && YR=$(date +%Y)
+            ARGS="$ARGS --start $(printf '%04d-%02d' $YR ${{ inputs.month }})"
+          fi
+          poetry run flep $ARGS
 
       - name: Delete existing EEX API cache
         run: |

--- a/flex_energy_price_calculator/models/base/__init__.py
+++ b/flex_energy_price_calculator/models/base/__init__.py
@@ -150,7 +150,13 @@ class BaseModel(ABC):
         self.skipped_days = skipped_days
         price_values = [x[1] for x in self.prices]
 
-        self.status_message = self.get_status_message(len(price_values), delta_days)
-        self.average_price = mean(price_values)
-        self.net_price = (self.average_price * STD_PROFILE_FACTOR + meta.fees) / CONVERSION_FACTOR
-        self.gross_price = self.net_price * TAXES
+        if not price_values:
+            self.average_price = 0.0
+            self.net_price = 0.0
+            self.gross_price = 0.0
+            self.status_message = "No data available"
+        else:
+            self.status_message = self.get_status_message(len(price_values), delta_days)
+            self.average_price = mean(price_values)
+            self.net_price = (self.average_price * STD_PROFILE_FACTOR + meta.fees) / CONVERSION_FACTOR
+            self.gross_price = self.net_price * TAXES


### PR DESCRIPTION
## Changes

**Commit 1** — `feat: add workflow_dispatch inputs for month/year`
- Add `month` (1-12) and `year` (YYYY) inputs to daily-report.yml
- Cron keeps default behavior (next month report)
- Manual dispatch with month set passes `--start YYYY-MM` to flep
- CLI already supports `--start` with `--format markdown`

**Commit 2** — `fix: handle empty price list gracefully`
- Guard `mean(price_values)` against empty list in `BaseModel.__init__`
- Sets prices to 0.0 + status "No data available" instead of raising `StatisticsError`
- Markdown report already catches the error and shows "No data available"
- Terminal mode no longer crashes

## Caveat
API only retains \~2 months of pre-delivery trade data. Past months work only if contract hasn't aged out.
- 2026-07 ✅
- 2026-06 ⚠️ partial (May 19-29 only)
- 2026-05 ❌ (only delivery month prices left)
- ≤2026-04 ❌ completely gone